### PR TITLE
Update jenkins base image to include java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.225
+FROM jenkins/jenkins:2.245-jdk11
 
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt


### PR DESCRIPTION
Building the docker image of the Spring Boot app leads to the following compile error because jenkins/jenkins:2.225 only includes java8:

> Task :compileJava FAILED
> FAILURE: Build failed with an exception.
> What went wrong:
> Execution failed for task ':compileJava'.
> Could not target platform: 'Java SE 11' using tool chain: 'JDK 8 (1.8)'.

I was following instructions on your post: 
https://tomgregory.com/building-a-spring-boot-application-in-docker-and-jenkins/?unapproved=89&moderation-hash=04cac9c3530f9d2c399d5216eb3e6605#comment-89
